### PR TITLE
予定管理をするAPIの初期設定とindexアクションの定義

### DIFF
--- a/api/app/controllers/calendar_events_controller.rb
+++ b/api/app/controllers/calendar_events_controller.rb
@@ -1,0 +1,11 @@
+class CalendarEventsController < ApplicationController
+
+  before_action :authentivate_user!
+
+  def index
+    user_id = current_user.id
+    calendar_events = CalendarEvent.where(user_id: user_id)
+    render json: calendar_events
+  end
+
+end

--- a/api/app/models/calendar_event.rb
+++ b/api/app/models/calendar_event.rb
@@ -1,0 +1,3 @@
+class CalendarEvent < ApplicationRecord
+  belongs_to :user
+end

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -6,4 +6,5 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   include DeviseTokenAuth::Concerns::User
+  has_one :calendar_event
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -6,4 +6,9 @@ Rails.application.routes.draw do
   namespace :auth do
     resources :sessions, only: %i[index]
   end
+
+  get '/calendar_events', to: 'calendar_events#index'
+  post '/calendar_events', to: 'calendar_events#create'
+  post '/calendar_events', to: 'calendar_events#update'
+
 end

--- a/api/db/migrate/20250319091558_create_calendar_events.rb
+++ b/api/db/migrate/20250319091558_create_calendar_events.rb
@@ -1,0 +1,12 @@
+class CreateCalendarEvents < ActiveRecord::Migration[8.0]
+  def change
+    create_table :calendar_events do |t|
+      t.string      :title
+      t.string      :description
+      t.string      :start_date
+      t.string      :end_date
+      t.references  :user, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_11_090306) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_19_091558) do
+  create_table "calendar_events", force: :cascade do |t|
+    t.string "title"
+    t.string "description"
+    t.string "start_date"
+    t.string "end_date"
+    t.integer "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_calendar_events_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "provider", default: "email", null: false
     t.string "uid", default: "", null: false
@@ -35,4 +46,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_11_090306) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
+
+  add_foreign_key "calendar_events", "users"
 end

--- a/api/test/controllers/calendar_events_controller_test.rb
+++ b/api/test/controllers/calendar_events_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CalendarEventsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/api/test/fixtures/calendar_events.yml
+++ b/api/test/fixtures/calendar_events.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/api/test/models/calendar_event_test.rb
+++ b/api/test/models/calendar_event_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CalendarEventTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
indexアクション（予定の一覧表示）の記述

# What(やったこと)
予定管理をするmodel(CalenderEvent)とtable(CalenderEvents)の作成
コントローラー(CalenderEvents)の作成
indexアクションの定義
<!-- PR の差分内容を簡潔に -->
table
CalenderEventsを追加
モデル
CalenderEventを追加
UserモデルとRDBの関係性を定義
コントローラー
CalenderEventsを追加
# Why(なぜやったか)
カレンダー予定の作成、更新などができるようにするため
<!-- 開発の背景、要件など -->
ユーザー情報に紐づいて予定が取得できるようにする事
# How(どうやったか)
CalenderEventsコントローラーのbefore_actionとしてdeviseのメソッドであるhttps://github.com/heartcombo/devise#controller-filters-and-helpers
before_action :authenticate_user!を使って認証機能を実装した
<!-- 実装の方針や詳細など -->
RDBの表現は
Userモデルにはhas_oneを記載して関連づけ
CalenderEventモデルにはbelongs_to :userを使って従属関係を指定した
### 画面キャプチャ
なし