### PR TITLE
フロント側でAPIを叩く関数を定義

### DIFF
--- a/front/src/lib/api/calenderEvent.js
+++ b/front/src/lib/api/calenderEvent.js
@@ -1,0 +1,34 @@
+import Cookies from "js-cookie"
+import client from "./client"
+
+export const getCalendarEvents = () => {
+    if (
+        !Cookies.get("_access_token") ||
+        !Cookies.get("_clien") ||
+        !Cookies,get("_uid")
+    )
+        return;
+    return client.get("/calendar_events",{
+        headers: {
+          "access-token": Cookies.get("_access_token"),
+           client: Cookies.get("_client"),
+           uid: Cookies.get("_uid"),
+        },
+    });
+};
+
+export const creaCalendarEvent = (params) => {
+    if (
+        !Cookies.get("_access_token") ||
+        !Cookies.get("_clien") ||
+        !Cookies,get("_uid")
+    )
+        return;
+    return client.put(`/calendae_events/${params.creaCalendarEventId}`,params, {
+        headers: {
+          "access-token": Cookies.get("_access_token"),
+           client: Cookies.get("_client"),
+           uid: Cookies.get("_uid"),
+        },
+    })
+}


### PR DESCRIPTION
認証情報をclientを使って実装した

# What(やったこと)
CalendarEventsの作成とUpdateの際に叩くAPIを定義した
<!-- PR の差分内容を簡潔に -->
front/src/lib/api/calenderEvent.jsを作成
APIを叩くファイルとして定義する
# Why(なぜやったか)
BEで定義したAPIとFEを繋げる
<!-- 開発の背景、要件など -->
認証情報を定義する
# How(どうやったか)

<!-- 実装の方針や詳細など -->

### 画面キャプチャ
<img width="655" alt="image" src="https://github.com/user-attachments/assets/c5e5f48f-34b3-4a3d-8d55-f90021803f17" />
